### PR TITLE
1.16 backport and add singleClickEnable option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,20 @@
 import java.util.concurrent.Callable
 
 plugins {
-    id 'fabric-loom' version '1.7-SNAPSHOT'
+    id 'fabric-loom' version '0.8-SNAPSHOT'
     id 'maven-publish'
     id 'com.github.breadmoirai.github-release' version "2.3.7"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 archivesBaseName = project.archives_base_name
-version = project.mod_version
+version = project.minecraft_version+'-'+project.mod_version+'+v'+new Date().format('yyMMdd')
 group = project.maven_group
 
 repositories {
+    mavenLocal()
     maven {
         name 'Gegy'
         url 'https://maven.gegy.dev'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21.1
-yarn_mappings=1.21.1+build.1
-loader_version=0.15.11
+minecraft_version=1.16.5
+yarn_mappings=1.16.5+build.1
+loader_version=0.11.1
 
 # Mod Properties
 mod_version=1.7.4
@@ -14,8 +14,8 @@ archives_base_name=one-click-crafting
 
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.102.0+1.21.1
+fabric_version=0.29.4+1.16
 # https://github.com/LambdAurora/SpruceUI
-spruceui_version=5.1.0+1.21
+spruceui_version=2.1.4+1.16
 # https://maven.terraformersmc.com/releases/com/terraformersmc/modmenu/
-modmenu_version=11.0.1
+modmenu_version=1.15.0

--- a/src/main/java/com/github/breadmoirai/oneclickcrafting/config/OneClickCraftingConfig.java
+++ b/src/main/java/com/github/breadmoirai/oneclickcrafting/config/OneClickCraftingConfig.java
@@ -29,6 +29,7 @@ public class OneClickCraftingConfig {
     private boolean alwaysOn = true;
     private boolean altHold = true;
     private boolean ctrlHold = true;
+    private boolean singleClickEnable = false;
     private boolean dropEnable = true;
 
     public static OneClickCraftingConfig getInstance() {
@@ -44,6 +45,7 @@ public class OneClickCraftingConfig {
                 instance.alwaysOn = config.alwaysOn;
                 instance.altHold = config.altHold;
                 instance.ctrlHold = config.ctrlHold;
+		instance.singleClickEnable = config.singleClickEnable;
                 instance.dropEnable = config.dropEnable;
             } catch (IOException e) {
                 e.printStackTrace();
@@ -84,6 +86,14 @@ public class OneClickCraftingConfig {
 
     public void setCtrlHold(boolean ctrlHold) {
         this.ctrlHold = ctrlHold;
+    }
+
+    public boolean isSingleClickEnable() {
+        return singleClickEnable;
+    }
+
+    public void setSingleClickEnable(boolean singleClickEnable) {
+        this.singleClickEnable = singleClickEnable;
     }
 
     public boolean isDropEnable() {

--- a/src/main/java/com/github/breadmoirai/oneclickcrafting/config/OneClickCraftingConfigScreen.java
+++ b/src/main/java/com/github/breadmoirai/oneclickcrafting/config/OneClickCraftingConfigScreen.java
@@ -1,22 +1,23 @@
 package com.github.breadmoirai.oneclickcrafting.config;
 
-import dev.lambdaurora.spruceui.Position;
-import dev.lambdaurora.spruceui.SpruceTexts;
-import dev.lambdaurora.spruceui.option.SpruceBooleanOption;
-import dev.lambdaurora.spruceui.screen.SpruceScreen;
-import dev.lambdaurora.spruceui.widget.SpruceButtonWidget;
-import dev.lambdaurora.spruceui.widget.container.SpruceOptionListWidget;
+import me.lambdaurora.spruceui.Position;
+import me.lambdaurora.spruceui.SpruceTexts;
+import me.lambdaurora.spruceui.option.SpruceBooleanOption;
+import me.lambdaurora.spruceui.screen.SpruceScreen;
+import me.lambdaurora.spruceui.widget.SpruceButtonWidget;
+import me.lambdaurora.spruceui.widget.container.SpruceOptionListWidget;
+import me.lambdaurora.spruceui.wrapper.VanillaButtonWrapper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
 
 @Environment(EnvType.CLIENT)
 public class OneClickCraftingConfigScreen extends SpruceScreen {
     private final Screen parent;
 
     public OneClickCraftingConfigScreen(Screen parent) {
-        super(Text.translatable("config.oneclickcrafting.title"));
+        super(new TranslatableText("config.oneclickcrafting.title"));
         this.parent = parent;
     }
 
@@ -36,42 +37,49 @@ public class OneClickCraftingConfigScreen extends SpruceScreen {
                 "config.oneclickcrafting.alt_hold",
                 config::isAltHold,
                 config::setAltHold,
-                Text.translatable("config.oneclickcrafting.alt_hold.tooltip")
+                new TranslatableText("config.oneclickcrafting.alt_hold.tooltip")
         );
         SpruceBooleanOption ctrlHold = new SpruceBooleanOption(
                 "config.oneclickcrafting.ctrl_hold",
                 config::isCtrlHold,
                 config::setCtrlHold,
-                Text.translatable("config.oneclickcrafting.ctrl_hold.tooltip")
+                new TranslatableText("config.oneclickcrafting.ctrl_hold.tooltip")
+        );
+        SpruceBooleanOption singleClickEnable = new SpruceBooleanOption(
+                "config.oneclickcrafting.single_click_enable",
+                config::isSingleClickEnable,
+                config::setSingleClickEnable,
+                new TranslatableText("config.oneclickcrafting.single_click_enable.tooltip")
         );
         SpruceBooleanOption dropEnable = new SpruceBooleanOption(
                 "config.oneclickcrafting.drop_enable",
                 config::isDropEnable,
                 config::setDropEnable,
-                Text.translatable("config.oneclickcrafting.drop_enable.tooltip")
+                new TranslatableText("config.oneclickcrafting.drop_enable.tooltip")
         );
 
         list.addSingleOptionEntry(alwaysOn);
         list.addSingleOptionEntry(ctrlHold);
         list.addSingleOptionEntry(altHold);
+        list.addSingleOptionEntry(singleClickEnable);
         list.addSingleOptionEntry(dropEnable);
 
-        SpruceButtonWidget done = new SpruceButtonWidget(Position.of(this, this.width / 2 + 4, this.height - 28), 150, 20, SpruceTexts.GUI_DONE,
+        VanillaButtonWrapper done = new SpruceButtonWidget(Position.of(this, this.width / 2 + 4, this.height - 28), 150, 20, SpruceTexts.GUI_DONE,
                 btn -> {
                     if (this.client != null) {
-                        this.client.setScreen(this.parent);
+                        this.client.method_29970(this.parent);
                     }
-                });
+                }).asVanilla();
 
-        addDrawableChild(list);
-        addDrawableChild(done);
+        this.children.add(list);
+        this.addButton(done);
     }
 
 
     @Override
-    public void close() {
+    public void onClose() {
         if (this.client != null) {
-            this.client.setScreen(parent);
+            this.client.method_29970(this.parent);
         }
         OneClickCraftingConfig.saveModConfig();
     }

--- a/src/main/java/com/github/breadmoirai/oneclickcrafting/config/OneClickCraftingConfigScreen.java
+++ b/src/main/java/com/github/breadmoirai/oneclickcrafting/config/OneClickCraftingConfigScreen.java
@@ -2,14 +2,17 @@ package com.github.breadmoirai.oneclickcrafting.config;
 
 import me.lambdaurora.spruceui.Position;
 import me.lambdaurora.spruceui.SpruceTexts;
+import me.lambdaurora.spruceui.background.SimpleColorBackground;
 import me.lambdaurora.spruceui.option.SpruceBooleanOption;
 import me.lambdaurora.spruceui.screen.SpruceScreen;
 import me.lambdaurora.spruceui.widget.SpruceButtonWidget;
+import me.lambdaurora.spruceui.widget.SpruceSeparatorWidget;
 import me.lambdaurora.spruceui.widget.container.SpruceOptionListWidget;
 import me.lambdaurora.spruceui.wrapper.VanillaButtonWrapper;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.TranslatableText;
 
 @Environment(EnvType.CLIENT)
@@ -19,12 +22,12 @@ public class OneClickCraftingConfigScreen extends SpruceScreen {
     public OneClickCraftingConfigScreen(Screen parent) {
         super(new TranslatableText("config.oneclickcrafting.title"));
         this.parent = parent;
-    }
+    };
 
     @Override
     protected void init() {
         super.init();
-        SpruceOptionListWidget list = new SpruceOptionListWidget(Position.of(0, 22), this.width, this.height - 36 - 22);
+        SpruceOptionListWidget list = new SpruceOptionListWidget(Position.of(0, 32), this.width, this.height - 36 - 32);
 
         OneClickCraftingConfig config = OneClickCraftingConfig.getInstance();
         SpruceBooleanOption alwaysOn = new SpruceBooleanOption(
@@ -63,8 +66,10 @@ public class OneClickCraftingConfigScreen extends SpruceScreen {
         list.addSingleOptionEntry(altHold);
         list.addSingleOptionEntry(singleClickEnable);
         list.addSingleOptionEntry(dropEnable);
+        list.setRenderTransition(false);
+        list.setBackground(new SimpleColorBackground(0, 0, 0, 0));
 
-        VanillaButtonWrapper done = new SpruceButtonWidget(Position.of(this, this.width / 2 + 4, this.height - 28), 150, 20, SpruceTexts.GUI_DONE,
+        VanillaButtonWrapper done = new SpruceButtonWidget(Position.of(this, this.width / 2  - 75, this.height - 28), 150, 20, SpruceTexts.GUI_DONE,
                 btn -> {
                     if (this.client != null) {
                         this.client.method_29970(this.parent);
@@ -75,11 +80,15 @@ public class OneClickCraftingConfigScreen extends SpruceScreen {
         this.addButton(done);
     }
 
+    @Override
+    public void renderTitle(MatrixStack matrices, int mouseX, int mouseY, float delta) {
+        drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 16, 16777215);
+    }
 
     @Override
     public void onClose() {
         if (this.client != null) {
-            this.client.method_29970(this.parent);
+            this.client.method_29970(this.parent); // setScreen
         }
         OneClickCraftingConfig.saveModConfig();
     }

--- a/src/main/java/com/github/breadmoirai/oneclickcrafting/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/breadmoirai/oneclickcrafting/mixin/ClientPlayNetworkHandlerMixin.java
@@ -13,7 +13,7 @@ public class ClientPlayNetworkHandlerMixin {
 
     @Inject(at = @At("TAIL"), method = "onScreenHandlerSlotUpdate(Lnet/minecraft/network/packet/s2c/play/ScreenHandlerSlotUpdateS2CPacket;)V")
     private void onScreenHandlerSlotUpdate(ScreenHandlerSlotUpdateS2CPacket packet, CallbackInfo ci) {
-        if (packet.getSlot() == 0 && packet.getStack() != null)
-            OneClickCraftingClient.getInstance().onResultSlotUpdated(packet.getStack());
+        if (packet.getSlot() == 0 && packet.getItemStack() != null)
+            OneClickCraftingClient.getInstance().onResultSlotUpdated(packet.getItemStack());
     }
 }

--- a/src/main/java/com/github/breadmoirai/oneclickcrafting/mixin/ClientPlayerInteractionManagerMixin.java
+++ b/src/main/java/com/github/breadmoirai/oneclickcrafting/mixin/ClientPlayerInteractionManagerMixin.java
@@ -2,7 +2,7 @@ package com.github.breadmoirai.oneclickcrafting.mixin;
 
 import com.github.breadmoirai.oneclickcrafting.client.OneClickCraftingClient;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
-import net.minecraft.recipe.RecipeEntry;
+import net.minecraft.recipe.Recipe;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ClientPlayerInteractionManager.class)
 public class ClientPlayerInteractionManagerMixin {
 
-    @Inject(at = @At("TAIL"), method = "clickRecipe(ILnet/minecraft/recipe/RecipeEntry;Z)V")
-    private void clickRecipe(int syncId, RecipeEntry<?> recipe, boolean craftAll, CallbackInfo ci) {
+    @Inject(at = @At("TAIL"), method = "clickRecipe(ILnet/minecraft/recipe/Recipe;Z)V")
+    private void clickRecipe(int syncId, Recipe<?> recipe, boolean craftAll, CallbackInfo ci) {
         OneClickCraftingClient.getInstance().recipeClicked(recipe);
     }
 }

--- a/src/main/java/com/github/breadmoirai/oneclickcrafting/mixin/KeyBindingAccessor.java
+++ b/src/main/java/com/github/breadmoirai/oneclickcrafting/mixin/KeyBindingAccessor.java
@@ -1,6 +1,6 @@
 package com.github.breadmoirai.oneclickcrafting.mixin;
 
-import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.options.KeyBinding;
 import net.minecraft.client.util.InputUtil;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;

--- a/src/main/resources/assets/oneclickcrafting/lang/en_us.json
+++ b/src/main/resources/assets/oneclickcrafting/lang/en_us.json
@@ -7,6 +7,8 @@
   "config.oneclickcrafting.ctrl_hold.tooltip": "Enables holding Ctrl to toggle the mod's functionality",
   "config.oneclickcrafting.drop_enable": "Enable Drop Key on Craft",
   "config.oneclickcrafting.drop_enable.tooltip": "Holding your drop key and clicking on a recipe will craft it and drop it instead of moving it to your inventory. Does not work with shift.",
+  "config.oneclickcrafting.single_click_enable": "Enable Single Click Crafting",
+  "config.oneclickcrafting.single_click_enable.tooltip": "Single click on a recipe will craft it if no other combination keys (e.g. drop key or shift) are pressed.",
   "category.oneclickcrafting.keybindings": "One Click Crafting",
   "key.oneclickcrafting.toggle_hold": "Toggle (Hold)"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,11 +27,11 @@
     "one-click-crafting.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.7",
+    "fabricloader": ">=0.11.1",
     "fabric-key-binding-api-v1": "*"
   },
   "recommends": {
-    "modmenu": ">=11.0.1",
-    "minecraft": ">=1.21.1"
+    "modmenu": ">=1.15.0",
+    "minecraft": ">=1.16.5"
   }
 }

--- a/src/main/resources/one-click-crafting.mixins.json
+++ b/src/main/resources/one-click-crafting.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.github.breadmoirai.oneclickcrafting.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_16",
   "mixins": [
 
   ],


### PR DESCRIPTION
Hi. Your mod is really usedul to me. So I backported it to 1.16.5 (not tested if 1.16.4 compatible).

The dependency SpruceUI was also modified by me (you can see Pairman/SpruceUI) to make it compatible.

I also added a config option to control whether to enable single click crafting. In my fork it's defaulted to off since I think misclicking happens more often.

If you find this backport helpful, you can (modify according to your interests, recompile and) publish it to benefit more users.